### PR TITLE
Refactoring of Api url constructor with `@mobily/ts-belt`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-template-redux",
       "version": "0.0.0",
       "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "^2.6.1",
         "axios": "^1.8.4",
         "neverthrow": "^8.2.0",
@@ -1950,6 +1951,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mobily/ts-belt": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.*"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "type-check": "tsc -b --noEmit"
   },
   "dependencies": {
+    "@mobily/ts-belt": "^3.13.1",
     "@reduxjs/toolkit": "^2.6.1",
     "axios": "^1.8.4",
     "neverthrow": "^8.2.0",


### PR DESCRIPTION
Installing `"@mobily/ts-belt"`
refactoring loadTracks `asyncThunk` function
This helped to abandon `eslint-disable-next-line`
